### PR TITLE
Run `Bundler.require` before running rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,6 @@
+require "bundler/setup"
+Bundler.require
+
 def windows?
   Rake::Win32.windows?
 end


### PR DESCRIPTION
This ensures that we're using the correct versions of gems, and fails early
when a gem is not installed.
