### PR TITLE
Use "TA" instead of "staff member" for installfest

### DIFF
--- a/sites/en/installfest/checklist.md
+++ b/sites/en/installfest/checklist.md
@@ -9,11 +9,11 @@
 
 1. Start the virtual machine: type `vagrant up`
 
-1. Connect to the virtual machine: type  `vagrant ssh`
+1. Connect to the virtual machine: type `vagrant ssh`
 
-1. Start the Ruby interactive editor:  type  `irb`
+1. Start the Ruby interactive editor: type `irb`
 
-1. Exit the Ruby interactive editor:  type  `exit`
+1. Exit the Ruby interactive editor: type `exit`
 
 1. Disconnect from the virtual machine by typing `exit`
 

--- a/sites/en/installfest/checklist.md
+++ b/sites/en/installfest/checklist.md
@@ -21,7 +21,7 @@
 
 1. From Finder or the Start menu, start Sublime Text or your text editor application.
 
-1. Get a setup confirmation sticker from a staff member and stick it on
+1. Get a setup confirmation sticker from a TA and stick it on
    your laptop where it will be visible when you return tomorrow.
 
 ### You're Done!
@@ -30,5 +30,5 @@ Congratulations, you're done with the Friday session. We'll see you at 9:30am
 tomorrow. Please bring the same laptop you used tonight.
 
 If you have any questions, comments, or feedback on tonight's material,
-don't hesitate to let a staff member know. We also have a feedback form
+don't hesitate to let a TA know. We also have a feedback form
 that you can use early and often to provide feedback about the workshop.

--- a/sites/en/installfest/checklist.md
+++ b/sites/en/installfest/checklist.md
@@ -9,7 +9,7 @@
 
 1. Start the virtual machine: type `vagrant up`
 
-1. Connect to the virtual machine: type  `vagrant ssh`  (this is the command line for the Virtual Machine)
+1. Connect to the virtual machine: type  `vagrant ssh`
 
 1. Start the Ruby interactive editor:  type  `irb`
 

--- a/sites/en/installfest/install_a_text_editor.md
+++ b/sites/en/installfest/install_a_text_editor.md
@@ -26,7 +26,7 @@ Type this in the Terminal to start Sublime:
 ```text
 /usr/bin/sublime-text
 ```
-Or, you can use your GUIs menus, as an icon has most likely been installed.
+Or, you can use your GUI's menus, as an icon has most likely been installed.
 
 ## 2. Set some basic preferences
 

--- a/sites/en/installfest/installfest.md
+++ b/sites/en/installfest/installfest.md
@@ -3,7 +3,8 @@
 </div>
 
 ### Goal
-Install Ruby, Install a Text Editor, and Start Coding
+
+**Install Ruby, Install a Text Editor, and Start Coding**
 
 At the end of this tutorial, you will have all the tools you need to write and
 run Ruby code. Work through these sections in order, and ask questions if you

--- a/sites/en/installfest/installfest.md
+++ b/sites/en/installfest/installfest.md
@@ -10,7 +10,7 @@ At the end of this tutorial, you will have all the tools you need to write and
 run Ruby code. Work through these sections in order, and ask questions if you
 get stuck! That's what the TAs and instructors are here for.
 
-When you are done with all the steps, find a staff member to go through the
+When you are done with all the steps, find a TA to go through the
 checklist with you.
 
 ### 1. Set Up Your Programming Environment
@@ -65,5 +65,5 @@ suggestions for using it more effectively: [Text Editor](install_a_text_editor)
 
 ### 4. Setup Checklist
 
-Find a staff member and run through the
+Find a TA and run through the
 [Installfest Completion Checklist](checklist).

--- a/sites/en/installfest/installfest.md
+++ b/sites/en/installfest/installfest.md
@@ -19,8 +19,8 @@ First, make sure you have downloaded the files for your operating system from
 the <a href="/downloads">Downloads page</a>. If you don't have them, you can get them
 from a TA with a USB drive.
 
-Choose the instructions below for your operating system. This will take you to
-a new page. Use your browser's back button to return here. Most students will
+Choose the instructions below for your operating system. _This will take you to
+a new page_. Use your browser's back button to return here. Most students will
 have one of the operating systems in this row.
 
 <table class="downloads-files">


### PR DESCRIPTION
- Remove misleading explanation of `vagrant ssh`
- Emphasize that students will go to a new page, since it's easy to miss
