### PR TITLE
Tell students to set their name/email in Git

### DIFF
--- a/sites/en/installfest/checklist.md
+++ b/sites/en/installfest/checklist.md
@@ -15,6 +15,10 @@
 
 1. Exit the Ruby interactive editor:  type  `exit`
 
+1. Check that your Git name is set: `git config --global user.name`
+
+1. Check that your Git email is set: `git config --global user.email`
+
 1. Disconnect from the virtual machine by typing `exit`
 
 1. Stop the virtual machine for the night:  type `vagrant halt`.

--- a/sites/en/installfest/set_up_virtual_machine.md
+++ b/sites/en/installfest/set_up_virtual_machine.md
@@ -105,6 +105,22 @@ You will see a welcome message something like this:
 
     RailsBridge-VM:~/workspace$
 
+## Set up git
+
+Let's set up Git, a way to track the code that you write tomorrow.
+
+Type this, replacing `"Your Name"` with your full name in quotes:
+
+    git config user.name "Your Name"
+
+The `--global` option tells Git to set your name system-wide, instead of in only
+one place.
+
+Now let's tell Git what your email is. Type the following, replacing `"Your
+Email"` with your email in quotes:
+
+    git config --global user.email "Your Email"
+
 ## Disconnect from the virtual machine (turning it on and off)
 
 When you're done working in the virtual machine, type `exit` to disconnect from the virtual machine.

--- a/sites/en/installfest/set_up_virtual_machine.md
+++ b/sites/en/installfest/set_up_virtual_machine.md
@@ -111,7 +111,7 @@ Let's set up Git, a way to track the code that you write tomorrow.
 
 Type this, replacing `"Your Name"` with your full name in quotes:
 
-    git config user.name "Your Name"
+    git config --global user.name "Your Name"
 
 The `--global` option tells Git to set your name system-wide, instead of in only
 one place.


### PR DESCRIPTION
We have dummy values set in Vagrant so it won't crash if this isn't done, but
it'll make their commits look better.

Fixes #36.
