### PR TITLE
New VirtualBox, Vagrant, msysgit versions for 2015-01

### DIFF
--- a/sites/en/downloads/downloads.md
+++ b/sites/en/downloads/downloads.md
@@ -30,10 +30,10 @@ Find the column for your OS, and download each file.
   <th>Linux (Ubuntu/Fedora)</th>
 </tr>
 <tr>
-  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2014-09.box">September 2014 VM Image</a></td>
-  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2014-09.box">September 2014 VM Image</a></td>
-  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2014-09.box">September 2014 VM Image</a></td>
-  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2014-09.box">September 2014 VM Image</a></td>
+  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2015-01.box">January 2015 VM Image</a></td>
+  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2015-01.box">January 2015 VM Image</a></td>
+  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2015-01.box">January 2015 VM Image</a></td>
+  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2015-01.box">January 2015 VM Image</a></td>
 </tr>
 <tr>
   <td><a href="http://download.virtualbox.org/virtualbox/4.3.20/VirtualBox-4.3.20-96996-OSX.dmg">VirtualBox 4.3 Installer</a></td>

--- a/sites/en/downloads/downloads.md
+++ b/sites/en/downloads/downloads.md
@@ -36,14 +36,14 @@ Find the column for your OS, and download each file.
   <td><a href="http://downloads.railsbridge.org/railsbridgevm-2014-09.box">September 2014 VM Image</a></td>
 </tr>
 <tr>
-  <td><a href="http://download.virtualbox.org/virtualbox/4.3.16/VirtualBox-4.3.16-95972-OSX.dmg">VirtualBox 4.3 Installer</a></td>
-  <td><a href="http://download.virtualbox.org/virtualbox/4.3.16/VirtualBox-4.3.16-95972-Win.exe">VirtualBox 4.3 Installer</a></td>
-  <td><a href="http://download.virtualbox.org/virtualbox/4.3.16/VirtualBox-4.3.16-95972-Win.exe">VirtualBox 4.3 Installer</a></td>
+  <td><a href="http://download.virtualbox.org/virtualbox/4.3.20/VirtualBox-4.3.20-96996-OSX.dmg">VirtualBox 4.3 Installer</a></td>
+  <td><a href="http://download.virtualbox.org/virtualbox/4.3.20/VirtualBox-4.3.20-96997-Win.exe">VirtualBox 4.3 Installer</a></td>
+  <td><a href="http://download.virtualbox.org/virtualbox/4.3.20/VirtualBox-4.3.20-96997-Win.exe">VirtualBox 4.3 Installer</a></td>
   <td><a href="https://www.virtualbox.org/wiki/Linux_Downloads">Choose your distro here</a></td>
 </tr>
 <tr>
-  <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.3.dmg">Vagrant 1.6 Installer</a></td>
-  <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.3.msi">Vagrant 1.6 Installer</a></td>
+  <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2.dmg>Vagrant 1.7 Installer</a></td>
+  <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2.msi">Vagrant 1.6 Installer</a></td>
   <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.4.msi">Vagrant 1.5 Installer</a></td>
   <td><a href="http://www.vagrantup.com/downloads.html">Choose your distro here</a></td>
 </tr>
@@ -56,7 +56,7 @@ Find the column for your OS, and download each file.
 <tr>
   <td></td>
   <td><a href="http://windows.github.com/">SSH (from GitHub)</a></td>
-  <td><a href="https://github.com/msysgit/msysgit/releases/download/Git-1.9.2-preview20140411/Git-1.9.2-preview20140411.exe">SSH (from Git)</a></td>
+  <td><a href="https://github.com/msysgit/msysgit/releases/download/Git-1.9.5-preview20141217/Git-1.9.5-preview20141217.exe">SSH (from Git)</a></td>
   <td></td>
 </tr>
 </table>

--- a/sites/en/installfest/set_up_virtual_machine.md
+++ b/sites/en/installfest/set_up_virtual_machine.md
@@ -14,7 +14,7 @@ that this may have been updated since our last workshop.
 
 *If you were unable to download the vm ahead of time, we have copies on USB drives.*
 
-In File Explorer or Finder, drag and drop "railsbridgevm-2014-09.box" from your downloads folder to your new workspace folder.
+In File Explorer or Finder, drag and drop "railsbridgevm-2015-01.box" from your downloads folder to your new workspace folder.
 
 Open your computer's command line. See the [Command Line page](command_line) for instructions on how to open it.
 
@@ -31,15 +31,15 @@ Move into your workspace directory:
 
 Type this:
 
-    vagrant box add railsbridge201409 ./railsbridgevm-2014-09.box
+    vagrant box add railsbridge201501 ./railsbridgevm-2015-01.box
 
 Then type:
 
-    vagrant init railsbridge201409
+    vagrant init railsbridge201501
 
 Here is what you should see (approximately):
 
-    [~/workspace]$ vagrant init railsbridge201409
+    [~/workspace]$ vagrant init railsbridge201501
     A `Vagrantfile` has been placed in this directory. You are now
     ready to `vagrant up` your first virtual environment! Please read
     the comments in the Vagrantfile as well as documentation on
@@ -73,7 +73,7 @@ It will do something like this:
 
     [~/workspace]$ vagrant up
     Bringing machine 'default' up with 'virtualbox' provider...
-    [default] Importing base box 'railsbridge201409'...
+    [default] Importing base box 'railsbridge201501'...
     [default] Matching MAC address for NAT networking...
     [default] Setting the name of the VM...
     [default] Clearing any previously set forwarded ports...

--- a/sites/en/ruby/command_line.step
+++ b/sites/en/ruby/command_line.step
@@ -107,7 +107,7 @@ cd rai
     message '... and hit `TAB`.'
     result 'cd railsbridge'
     message 'Hit `TAB` twice'
-    result 'railsbridge_ruby/ railsbridgevm-2014-09.box'
+    result 'railsbridge_ruby/ railsbridgevm-2015-01.box'
     message 'When there are multiple matches, it will show you the options. Type `_`'
     result 'cd railsbridge_'
     message '... and hit `TAB` again.'


### PR DESCRIPTION
I'm planning on building the VM with VirtualBox 4.3.20 and Vagrant 1.7.2. For now, I am leaving the older Vagrant version for XP/Vista untouched. However, looked around for more info on the problem, and found these notes from another workshop of some sort:

https://github.com/dab/bemup-workshop-vagrant/blob/d2086d7a29238ac3edadff1326231116bd9bd932/README.md

So maybe we should just collapse the Windows columns and walk the couple unfortunate students through that? I imagine this should have a page like the OS X 10.5 page, which I could write up.

Unfortunately everything about old Windows systems is in theory until we try it in practice :-/
