### PR TITLE
Fix vagrant download link and version number

### DIFF
--- a/sites/en/downloads/downloads.md
+++ b/sites/en/downloads/downloads.md
@@ -42,8 +42,8 @@ Find the column for your OS, and download each file.
   <td><a href="https://www.virtualbox.org/wiki/Linux_Downloads">Choose your distro here</a></td>
 </tr>
 <tr>
-  <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2.dmg>Vagrant 1.7 Installer</a></td>
-  <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2.msi">Vagrant 1.6 Installer</a></td>
+  <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2.dmg">Vagrant 1.7 Installer</a></td>
+  <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2.msi">Vagrant 1.7 Installer</a></td>
   <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.4.msi">Vagrant 1.5 Installer</a></td>
   <td><a href="http://www.vagrantup.com/downloads.html">Choose your distro here</a></td>
 </tr>


### PR DESCRIPTION
Ran into a broken link when running through the installfest
