### PR TITLE
Explain Ruby comments and remove them from IRB examples

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,7 +1,7 @@
 en:
   captions:
     terminal: "Type this in the terminal:"
-    irb: "Type this in irb:"
+    irb: "Type this in irb, hitting Enter after each line:"
     result: "Expected result:"
     fuzzy_result: "Approximate expected result:"
     link: "Go on to"

--- a/sites/en/ruby/booleans.step
+++ b/sites/en/ruby/booleans.step
@@ -69,19 +69,30 @@ end
 step do
     message "We can check more than one condition with `and` and `or` . `&&` and `||` (two pipes) is another notation for `and` and `or`."
     message "We do something like this when we Google for 'microsoft and cambridge and not seattle'"
+    message "Let's type some code into IRB. First, let's define variables:"
     irb <<-IRB
-      # First let's define variables:
       yes = true
       no = false
-      # Now experiment.  Boolean rule 1:  AND means everything must be true.
-      # true and true are true
+    IRB
+
+    message <<-CONTENT
+      Now experiment. Boolean rule 1:  AND means everything must be true. For example, `true`
+      combined with `true` is `true`:
+    CONTENT
+    irb <<-IRB
       yes and yes
       yes && yes
-      # true and false fail the test - AND means everything must be true
+    IRB
+
+    message "`true` combined with `false` fails the test because `and` means everything must be true:"
+    irb <<-IRB
       yes and no
       no and yes
       no and no
-      # Boolean rule 2: OR says at least one must be true.
+    IRB
+
+    message "Boolean rule 2: `or` says at least one must be true:"
+    irb <<-IRB
       yes or no
       yes || no
       yes or yes

--- a/sites/en/ruby/nil.step
+++ b/sites/en/ruby/nil.step
@@ -55,24 +55,27 @@ step do
 end
 
 step do
-    message "How can we avoid these errors?  There are a few ways to tell if something is nil."
+  message "How can we avoid these errors?  There are a few ways to tell if something is nil. Let's try them!"
 
-irb <<-IRB
-word = "something"
-word.nil?
-word = nil
-word.nil?
-# Remember, two equals signs asks if something is equal
-word == nil
-IRB
+  irb <<-IRB
+    word = "something"
+    word.nil?
+    word = nil
+    word.nil?
+  IRB
 
-    message "What's going on here?"
-    source_code <<-CONTENT
+  message "Remember, two equals signs asks if something is equal:"
+  irb "word == nil"
+
+  message "What's going on here?"
+
+  # Putting the marker in single quotes prevents interpolation
+  source_code <<-'CONTENT'
     name = nil
     if name.nil?
       puts "The name hasn't been set yet."
     else
-      puts "Your name is \#{name}"
+      puts "Your name is #{name}"
     end
   CONTENT
 end

--- a/sites/en/ruby/numbers_and_arithmetic.step
+++ b/sites/en/ruby/numbers_and_arithmetic.step
@@ -57,11 +57,9 @@ step do
 end
 
 step do
-  irb <<-TRYME
-
-4 / 0
-TRYME
-  message "Uh oh! Notice how we did not get a result here. The ruby interpreter raised an error. These errors tell the programmer that they tried to do something that the interpreter does not like or cannot use. Each error has a classification and a message. In this case, we get a `ZeroDivisionError` with the message: divided by 0"
+  message "Let's try the following, which will intentionally not work:"
+  irb "4 / 0"
+  message "Uh oh! Notice how we did not get a result here. Ruby raised an error. These errors tell the programmer that they tried to do something that the interpreter does not like or cannot use. Each error has a classification and a message. In this case, we get a `ZeroDivisionError` with the message: divided by 0"
 end
 
 challenge do

--- a/sites/en/ruby/running_programs_from_a_file.step
+++ b/sites/en/ruby/running_programs_from_a_file.step
@@ -27,6 +27,9 @@ step do
   message "Start your text editor."
   message "In your text editor, create a new file called **my_program.rb**"
   type_in_file "my_program.rb", <<-CONTENTS
+# This is a comment line.
+# Comment lines start with a pound sign, and the computer ignores them.
+# Since the computer ignores them you can use them for notes to yourself.
 puts 'This code is in a file!'
 some_variable = 19
 puts "I stored a variable with the value #\{some_variable\}!"


### PR DESCRIPTION
- Tell students to hit Enter after each line in IRB (a minor source of confusion in the past)
- Remove inline Ruby comments from IRB examples. tudents have gotten very confused by the comments in the past.

This addresses https://github.com/railsbridge-boston/docs/issues/12.

One of the issues raised in that PR is that we should explain comments better. I did a quick grep and I don't think we mention comments at all, so I added a quick explanation of comments near the first lesson. I don't think IRB is the right place to put comments either way, so I moved them into the text.
