### PR TITLE
Move all Git configuration to Rails extra credit

### DIFF
--- a/sites/en/installfest/checklist.md
+++ b/sites/en/installfest/checklist.md
@@ -15,10 +15,6 @@
 
 1. Exit the Ruby interactive editor: type `exit`
 
-1. Check that your Git name is set: `git config --global user.name`
-
-1. Check that your Git email is set: `git config --global user.email`
-
 1. Disconnect from the virtual machine by typing `exit`
 
 1. Stop the virtual machine for the night:  type `vagrant halt`.

--- a/sites/en/installfest/set_up_virtual_machine.md
+++ b/sites/en/installfest/set_up_virtual_machine.md
@@ -105,22 +105,6 @@ You will see a welcome message something like this:
 
     RailsBridge-VM:~/workspace$
 
-## Set up git
-
-Let's set up Git, a way to track the code that you write tomorrow.
-
-Type this, replacing `"Your Name"` with your full name in quotes:
-
-    git config --global user.name "Your Name"
-
-The `--global` option tells Git to set your name system-wide, instead of in only
-one place.
-
-Now let's tell Git what your email is. Type the following, replacing `"Your
-Email"` with your email in quotes:
-
-    git config --global user.email "Your Email"
-
 ## Disconnect from the virtual machine (turning it on and off)
 
 When you're done working in the virtual machine, type `exit` to disconnect from the virtual machine.

--- a/sites/en/intro-to-rails/add_the_project_to_a_git_repo.step
+++ b/sites/en/intro-to-rails/add_the_project_to_a_git_repo.step
@@ -7,6 +7,26 @@ goals do
 end
 
 steps do
+  step do
+    message <<-MARKDOWN
+      Let's set up Git, a way to track the code that you write tomorrow.
+    MARKDOWN
+
+    console_with_message "Type this, but with your full name in the quotes:",
+      'git config --global user.name "First Name Last Name"'
+
+    message <<-MARKDOWN
+      The `--global` option tells Git to set your name system-wide, instead of in only
+      one place.
+
+      Now let's tell Git what your email is.
+    MARKDOWN
+
+    console_with_message(
+      "Type the following, replacing the email with your email in the quotes:",
+      'git config --global user.email "your_name@your_email.com"'
+    )
+  end
 
   step do
     console "git init"


### PR DESCRIPTION
Instead of telling everyone to configure Git during the Installfest, we now have them configure and use Git all in one place, at the end of the Rails course.

Addresses #51.
