### PR TITLE
`rails server -b0.0.0.0` to work with Vagrant

### DIFF
--- a/sites/en/intro-to-rails/CRUD_with_scaffolding.step
+++ b/sites/en/intro-to-rails/CRUD_with_scaffolding.step
@@ -16,7 +16,8 @@ end
 steps do
 
   step do
-    console "rails server"
+    console "rails server -b0.0.0.0"
+    message "We need the `-b0.0.0.0` part so that Vagrant can connect to your server."
   end
 
   step do

--- a/sites/en/intro-to-rails/running_your_application_locally.step
+++ b/sites/en/intro-to-rails/running_your_application_locally.step
@@ -5,7 +5,7 @@ end
 
 steps do
   step do
-    console "rails server"
+    console "rails server -b0.0.0.0"
   end
 
   step do


### PR DESCRIPTION
> Rails 4.2 requires the option -b 0.0.0.0 to bind to all interfaces (by
> default, and this is new in 4.2, it will only listen on 127.0.0.1, which
> cannot take Vagrant-forwarded connections).

https://github.com/railsbridge-boston/railsbridge-vm/issues/10#issuecomment-115823610
