### PR TITLE
Get rid of the workspace directory, create a folder on the desktop

### DIFF
--- a/sites/en/installfest/checklist.md
+++ b/sites/en/installfest/checklist.md
@@ -5,7 +5,7 @@
   - **On Windows:** open up **Git Bash** from your desktop or All Programs menu. Do not use Power Shell or Command Prompt! It doesn't support the ssh command that we need.
   - **On Linux:** press Ctrl + Alt + T or Find Terminal under the Accessories category of your applications menu.
 
-1. Go to the workspace folder: type `cd ~/workspace`
+1. Go to the RailsBridge folder: type `cd Desktop` then `cd railsbridge`
 
 1. Start the virtual machine: type `vagrant up`
 

--- a/sites/en/installfest/checklist.md
+++ b/sites/en/installfest/checklist.md
@@ -5,7 +5,7 @@
   - **On Windows:** open up **Git Bash** from your desktop or All Programs menu. Do not use Power Shell or Command Prompt! It doesn't support the ssh command that we need.
   - **On Linux:** press Ctrl + Alt + T or Find Terminal under the Accessories category of your applications menu.
 
-1. Go to the RailsBridge folder: type `cd Desktop` then `cd railsbridge`
+1. Go to the RailsBridge folder: type `cd ~/Desktop/railsbridge`
 
 1. Start the virtual machine: type `vagrant up`
 

--- a/sites/en/installfest/command_line_extra_credit.md
+++ b/sites/en/installfest/command_line_extra_credit.md
@@ -44,7 +44,7 @@ Now you can generate some ASCII art. Try this command:
 
 You should see output like this:
 
-    vagrant@precise32:~/workspace$ curl 'http://artii.herokuapp.com/make?text=I+love+ruby'
+    RailsBridge-VM:/vagrant$ curl 'http://artii.herokuapp.com/make?text=I+love+ruby'
       _____   _                             _
      |_   _| | |                           | |
        | |   | | _____   _____   _ __ _   _| |__  _   _
@@ -52,7 +52,7 @@ You should see output like this:
       _| |_  | | (_) \ V /  __/ | |  | |_| | |_) | |_| |
      |_____| |_|\___/ \_/ \___| |_|   \__,_|_.__/ \__, |
                                                    __/ |
-                                                  |___/ vagrant@precise32:~/workspace$
+                                                  |___/ RailsBridge-VM:/vagrant$
 
 Change the end of the command string to generate your own message.
 
@@ -70,7 +70,7 @@ Now you can check the weather with this command:
 
 Example output:
 
-    vagrant@precise32:~/workspace$ weather BOS
+    RailsBridge-VM:/vagrant$ weather BOS
     Current conditions at Boston Logan International, MA (KBOS)
     Last updated Oct 04, 2013 - 09:54 AM EDT / 2013.10.04 1354 UTC
     Temperature: 66.0 F (18.9 C)

--- a/sites/en/installfest/installfest.md
+++ b/sites/en/installfest/installfest.md
@@ -1,5 +1,5 @@
 <div class="alert alert-info">
-<strong>Hey, read this</strong>: You don't need to read this before the workshop. We'll go over it during Railsbridge.
+<strong>Students! If you've gotten this far</strong>: You don't need to read this before the workshop. We'll go over it when everyone is there.
 </div>
 
 ### Goal

--- a/sites/en/installfest/set_up_virtual_machine.md
+++ b/sites/en/installfest/set_up_virtual_machine.md
@@ -1,6 +1,11 @@
-## Setting up a workspace
+## Setting up a folder to work in
 
-Open Finder or File Explorer.  By default, they open to your home directory.  Create a folder named "workspace".  If you've attended our Ruby workshop before, you already have this folder.
+Go to your desktop. If you're downloading the files, right-click to create a
+new, empty folder and call it `railsbridge`. If you're installing files from
+one of the USB drives at the workshop, copy the `railsbridge` folder to your
+computer by dragging it to your desktop.
+
+*Note that the name `railsbridge` should be lowercase.*
 
 This directory will be shared between the virtual machine and your computer. Like sharing files between two real computers with Dropbox or Google Docs, files need to be saved in a place that both your computer and the virtual machine can see. Save all your work in the hands-on exercises here so they can be run in the virtual machine.
 
@@ -12,9 +17,9 @@ Before the workshop, you might have <a href="/downloads">downloaded</a> the
 RailsBridge virtual machine image, and saved it in the Downloads folder.  Note
 that this may have been updated since our last workshop.
 
-*If you were unable to download the vm ahead of time, we have copies on USB drives.*
+*If you were unable to download the VM ahead of time, we have copies on USB drives.*
 
-In File Explorer or Finder, drag and drop "railsbridgevm-2016-04.box" from your downloads folder to your new workspace folder.
+In File Explorer or Finder, drag and drop "railsbridgevm-2016-04.box" from your downloads folder to your new RailsBridge folder.
 
 Open your computer's command line. (Windows users, open Git Bash.) See the [Command Line page](command_line) for instructions on how to open it.
 
@@ -25,9 +30,10 @@ Go to your home directory:
 
     cd
 
-Move into your workspace directory:
+Move into your desktop, then into the RailsBridge folder:
 
-    cd workspace
+    cd Desktop
+    cd railsbridge
 
 Type this:
 
@@ -39,7 +45,7 @@ Then type:
 
 Here is what you should see (approximately):
 
-    [~/workspace]$ vagrant init railsbridge201604
+    Your-Computer:railsbridge$ vagrant init railsbridge201604
     A `Vagrantfile` has been placed in this directory. You are now
     ready to `vagrant up` your first virtual environment! Please read
     the comments in the Vagrantfile as well as documentation on
@@ -49,7 +55,11 @@ Type this to list all the files you've made:
 
     ls
 
-Look at the "workspace" folder in Finder or File Explorer. You'll notice it now contains a file called Vagrantfile.  This contains configuration information that Vagrant needs to start and connect to the new virtual machine.  We have to have a command line open and be in this folder when we start or connect to the vm so Vagrant can read the configuration information.
+Look at the `railsbridge` folder in Finder or File Explorer. You'll notice it
+now contains a file called `Vagrantfile`.  This contains configuration
+information that Vagrant needs to start and connect to the new virtual
+machine.  We have to have a command line open and be in this folder when we
+start or connect to the vm so Vagrant can read the configuration information.
 
 Leave this Finder or File Explorer window open for the next step.
 
@@ -60,9 +70,9 @@ The virtual machine has to be running in order to use it.  There are two ways to
 
 ### Start and Connect Through The Commandline
 
-If you closed your command line, open it again and type `cd workspace` to return
-to the workspace folder.  This folder contains the file Vagrantfile, which has
-the configuration settings needed to start the vm.
+If you closed your command line, open it again and type `cd Desktop; cd
+railsbridge` to return to your folder.  This folder contains the file
+Vagrantfile, which has the configuration settings needed to start the vm.
 
 
 From the command line type:
@@ -71,7 +81,7 @@ From the command line type:
 
 It will do something like this:
 
-    [~/workspace]$ vagrant up
+    Your-Computer:railsbridge$ vagrant up
     Bringing machine 'default' up with 'virtualbox' provider...
     [default] Importing base box 'railsbridge201604'...
     [default] Matching MAC address for NAT networking...
@@ -96,14 +106,14 @@ To use the virtual machine, you must connect to it.  From the command line, type
 
 You will see a welcome message something like this:
 
-    [~/workspace]$ vagrant ssh
+    Your-Computer:railsbridge$ vagrant ssh
     Welcome to Ubuntu 14.04 LTS (GNU/Linux 3.13.0-24-generic i686)
     * Documentation:  https://help.ubuntu.com/
 
     Welcome to the RailsBridge Boston virtual machine!
     ...
 
-    RailsBridge-VM:~/workspace$
+    RailsBridge-VM:/vagrant$
 
 ## Disconnect from the virtual machine (turning it on and off)
 
@@ -116,7 +126,7 @@ And close the command line window.
 When you want to use the virtual machine (tomorrow morning, for instance),
 start your machine. Open the command line, then:
 
-    cd ~/workspace
+    cd ~/Desktop/railsbridge
     vagrant up
     vagrant ssh
 
@@ -129,7 +139,7 @@ start your machine. Open the command line, then:
 To open an extra command line
 on the virtual machine, open another command line window, then type:
 
-    cd ~/workspace
+    cd ~/Desktop/railsbridge
     vagrant ssh
 
 [« Back to Installfest](/installfest)

--- a/sites/en/installfest/set_up_virtual_machine.md
+++ b/sites/en/installfest/set_up_virtual_machine.md
@@ -19,21 +19,17 @@ that this may have been updated since our last workshop.
 
 *If you were unable to download the VM ahead of time, we have copies on USB drives.*
 
-In File Explorer or Finder, drag and drop "railsbridgevm-2016-04.box" from your downloads folder to your new RailsBridge folder.
+In File Explorer or Finder, drag and drop "railsbridgevm-2016-04.box" from
+your Downloads folder to your new `railsbridge` folder.
 
 Open your computer's command line. (Windows users, open Git Bash.) See the [Command Line page](command_line) for instructions on how to open it.
 
 <!-- INSTRUCTORS: please remember to update all occurrences of the box -->
 <!-- name below when the VM version changes. -->
 
-Go to your home directory:
+Go to your new `railsbridge` directory:
 
-    cd
-
-Move into your desktop, then into the RailsBridge folder:
-
-    cd Desktop
-    cd railsbridge
+    cd ~/Desktop/railsbridge
 
 Type this:
 
@@ -141,5 +137,12 @@ on the virtual machine, open another command line window, then type:
 
     cd ~/Desktop/railsbridge
     vagrant ssh
+
+Note: you can also get to your `railsbridge` directory this way, if `~` is
+inconvenient to get to on your keyboard:
+
+    cd
+    cd Desktop
+    cd railsbridge
 
 [« Back to Installfest](/installfest)

--- a/sites/en/installfest/set_up_virtual_machine.md
+++ b/sites/en/installfest/set_up_virtual_machine.md
@@ -1,26 +1,32 @@
-## Setting up a folder to work in
+## Creating a folder to work in
 
-Go to your desktop. If you're downloading the files, right-click to create a
-new, empty folder and call it `railsbridge`. If you're installing files from
-one of the USB drives at the workshop, copy the `railsbridge` folder to your
-computer by dragging it to your desktop.
+Your first task is to create a folder that will hold everything you create
+during the workshop.
 
-*Note that the name `railsbridge` should be lowercase.*
+This folder will be shared between the virtual machine and your computer. Like sharing files between two real computers with Dropbox or Google Docs, files need to be saved in a place that both your computer and the virtual machine can see. Save all your work in the hands-on exercises here so they can be run in the virtual machine.
 
-This directory will be shared between the virtual machine and your computer. Like sharing files between two real computers with Dropbox or Google Docs, files need to be saved in a place that both your computer and the virtual machine can see. Save all your work in the hands-on exercises here so they can be run in the virtual machine.
-
-## Set up the virtual machine
-
-This is a one-time step to create the virtual machine for the workshop.
-
-Before the workshop, you might have <a href="/downloads">downloaded</a> the
-RailsBridge virtual machine image, and saved it in the Downloads folder.  Note
-that this may have been updated since our last workshop.
+How you will create this folder will depend on whether or not you downloaded
+the Installfest files before the workshop.
 
 *If you were unable to download the VM ahead of time, we have copies on USB drives.*
 
+### If You Downloaded the Files Already
+
+Create a new folder on your desktop by right-clicking and selecting "New
+Folder". Name it `railsbridge`.
+
+*Note that the name `railsbridge` should be lowercase.*
+
 In File Explorer or Finder, drag and drop "railsbridgevm-2016-04.box" from
 your Downloads folder to your new `railsbridge` folder.
+
+### If You're Using a USB Drive at the Workshop
+
+Drag the `railsbridge` folder from the USB drive to your desktop.
+
+## Set up the virtual machine
+
+*This is a one-time step to create the virtual machine for the workshop.*
 
 Open your computer's command line. (Windows users, open Git Bash.) See the [Command Line page](command_line) for instructions on how to open it.
 
@@ -30,6 +36,8 @@ Open your computer's command line. (Windows users, open Git Bash.) See the [Comm
 Go to your new `railsbridge` directory:
 
     cd ~/Desktop/railsbridge
+
+*If you've been to a workshop before, please ask a TA for help removing your old VM image before proceeding.*
 
 Type this:
 
@@ -63,13 +71,13 @@ Leave this Finder or File Explorer window open for the next step.
 
 The virtual machine has to be running in order to use it.  There are two ways to start it.
 
-
 ### Start and Connect Through The Commandline
+
+*This is how you will start up and shut down your VM every time you use it.*
 
 If you closed your command line, open it again and type `cd Desktop; cd
 railsbridge` to return to your folder.  This folder contains the file
 Vagrantfile, which has the configuration settings needed to start the vm.
-
 
 From the command line type:
 

--- a/sites/en/intro-to-rails/creating_a_rails_application.step
+++ b/sites/en/intro-to-rails/creating_a_rails_application.step
@@ -10,31 +10,13 @@ steps do
   tip "If you have _any_ problems, contact a TA immediately."
 
   step do
+    message "If you are not in the virtual machine, start in and `vagrant ssh` in. Ask a TA if you need help."
     message "If you are still in irb, type exit to get back to your virtual machine's command line prompt."
   end
 
   step do
-    console "cd ~/workspace"
-    message "This command sets our workspace directory as our current directory."
-  end
-
-  step do
-    console "mkdir railsbridge"
-    message "`mkdir` (MaKe DIRectory) creates a new directory for us to store our project in."
-  end
-
-  step do
-    console "cd railsbridge"
-  end
-
-  step do
-    message "Check to see if you have any existing suggestotron apps from a previous workshop."
-    console "ls"
-    message "That command will list the files in your railsbridge directory. If you have any old suggestotron apps in that list, you can remove them to prevent hiccups:"
-    console "rm -rf suggestotron"
-  end
-
-  step do
+    # NOTE: this is the place where we would add the app template ( -m ~/vm.rb )
+    # if we wanted to do that instead of passing -b to every server invocation
     console "rails new suggestotron"
     message "`rails new` creates a new Rails project with the given name."
     message "In this case we told it to create a new project called `suggestotron`. We'll go into detail on exactly what it did shortly."

--- a/sites/en/intro-to-rails/intro-to-rails.step
+++ b/sites/en/intro-to-rails/intro-to-rails.step
@@ -51,9 +51,7 @@ show up for RailsBridge on Saturday.
 You can verify that you have everything working by trying this out in your terminal:
 
 <div class="console"><pre>
-$ cd
-$ cd Desktop
-$ cd railsbridge
+$ cd ~/Desktop/railsbridge
 $ vagrant up
 $ vagrant ssh
 $ irb

--- a/sites/en/intro-to-rails/intro-to-rails.step
+++ b/sites/en/intro-to-rails/intro-to-rails.step
@@ -51,7 +51,9 @@ show up for RailsBridge on Saturday.
 You can verify that you have everything working by trying this out in your terminal:
 
 <div class="console"><pre>
-$ cd ~/workspace
+$ cd
+$ cd Desktop
+$ cd railsbridge
 $ vagrant up
 $ vagrant ssh
 $ irb

--- a/sites/en/ruby/command_line.step
+++ b/sites/en/ruby/command_line.step
@@ -50,17 +50,17 @@ step do
 end
 
 step do
-  console 'cd workspace'
+  console 'cd Desktop'
   message '`cd` means **c**hange **d**irectory. You use `cd` when you want to move from the current directory into some other directory.'
   console 'pwd'
-  message "Notice how it changed? The working directory ends in '/workspace'."
+  message "Notice how it changed? The working directory now ends in 'Desktop'."
 end
 
 step do
-  console 'mkdir railsbridge_ruby'
+  console 'mkdir example_folder'
   message '`mkdir` means **m**ake **d**irectory. You use `mkdir` when you want to create a new directory.'
   console 'ls'
-  message 'Now the directory "railsbridge_ruby" shows up in the list.'
+  message 'Now the directory "example_folder" shows up in the list.'
   message 'The command line is just one way of manipulating the files on your computer. Try to find the new directory you created in Finder or Windows Explorer.'
   message 'If you get an error saying the directory already exists, maybe someone did these steps on your computer before. Don\'t fret.'
 end
@@ -76,7 +76,7 @@ step do
 
 What\'s your home directory?"
   console 'pwd'
-  message "Remember that you can always get back to your home with `cd ~`."
+  message "Remember that you can always get back to your home with `cd ~` or just `cd`."
 end
 
 step do
@@ -85,7 +85,7 @@ step do
     console 'cd -'
     message 'What command shows you your current directory?'
     console 'pwd'
-    message 'You should be back in your workspace. This will match the output from `pwd` from step 4'
+    message 'You should be back in your desktop. This will match the output from `pwd` from step 4'
 end
 
 
@@ -107,11 +107,11 @@ cd rai
     message '... and hit `TAB`.'
     result 'cd railsbridge'
     message 'Hit `TAB` twice'
-    result 'railsbridge_ruby/ railsbridgevm-2016-04.box'
+    result 'railsbridge/railsbridgevm-2016-04.box'
     message 'When there are multiple matches, it will show you the options. Type `_`'
-    result 'cd railsbridge_'
+    result 'cd example_'
     message '... and hit `TAB` again.'
-    result 'railsbridge_ruby/'
+    result 'example_folder/'
     message <<-LINES
 Autocomplete will be as smart as it can.  If you started with `cd`, it will list directories.
      If it could be a command, it will suggest commands.

--- a/sites/en/ruby/irb.step
+++ b/sites/en/ruby/irb.step
@@ -10,8 +10,7 @@ step do
     that runs Ruby code as you type it in."
   message "Start irb on the **virtual machine**. Any time we ask you to use irb, it should be on the Virtual Machine"
   console <<-LINES
-    cd Desktop
-    cd railsbridge
+    cd ~/Desktop/railsbridge
     vagrant up
     vagrant ssh
   LINES

--- a/sites/en/ruby/irb.step
+++ b/sites/en/ruby/irb.step
@@ -10,11 +10,12 @@ step do
     that runs Ruby code as you type it in."
   message "Start irb on the **virtual machine**. Any time we ask you to use irb, it should be on the Virtual Machine"
   console <<-LINES
-    cd ~/workspace
+    cd Desktop
+    cd railsbridge
     vagrant up
     vagrant ssh
   LINES
-  result "RailsBridge-VM:~/workspace$"
+  result "RailsBridge-VM:/vagrant$"
   console "irb"
   result "irb(main): 001 >"
   message "The prompt changed.  This is irb's way of reminding you that it's

--- a/sites/en/ruby/ruby.step
+++ b/sites/en/ruby/ruby.step
@@ -27,7 +27,7 @@ You can verify that you have everything working by following steps 1 through 4 o
 
 NOTE: When writing a command after the $ sign in your terminal, or in IRB, just press Enter or Return to execute it.
 
-1. To go to the workspace folder: type `cd ~/workspace`
+1. To go to the RailsBridge folder: type `cd ~/Desktop/railsbridge`
 
 1. To start the virtual machine: type `vagrant up`
 

--- a/sites/en/ruby/running_programs_from_a_file.step
+++ b/sites/en/ruby/running_programs_from_a_file.step
@@ -40,8 +40,9 @@ step do
   message <<-INFO
 Save the file.
 
-Save the file in `workspace` -  the same folder you created the virtual machine. That folder is shared
-between your laptop and the vm, like Google Drive.
+Save the file in `railsbridge` in your desktop - the folder shared with your
+virtual machine. Any files your put there show up in `/vagrant` on the VM, and
+vice versa, like Dropbox or Google Drive.
 
 Did you notice we added  `.rb` at the end of the name? It's standard practice to
 name Ruby files this way, to help people and tools recognize the file contains
@@ -73,7 +74,7 @@ end
 
 
 step do
-  message "Now run the code.  Stay in your workspace directory on the Virtual Machine."
+  message "Now run the code.  Stay in /vagrant on the Virtual Machine."
   console "ruby my_program.rb"
   result <<-CONTENTS
 This code is in a file!

--- a/sites/en/ruby/using_virtual_machines.step
+++ b/sites/en/ruby/using_virtual_machines.step
@@ -9,7 +9,7 @@ end
 
 goals do
   goal "Define virtual machine, Vagrant, and VirtualBox"
-  goal "Find your workspace directory"
+  goal "Find your shared directory"
   goal "Start and halt Vagrant"
   goal "Connect to and exit Vagrant"
 end
@@ -58,7 +58,7 @@ step do
 Vagrant is a tool for running a virtual machine. It will start and stop the
 VM, and let you connect to it so you can use it.
 
-During the Installfest you made a folder called "workspace" and ran some vagrant
+During the Installfest you made a folder called "railsbridge" and ran some vagrant
 commands to set up the RailsBridge image.
 
 It created a configuration file named Vagrantfile. Vagrant needs the config
@@ -108,7 +108,7 @@ end
 step do
   message 'In some cases you will now want to connect to your Virtual Machine.'
   console 'vagrant ssh'
-  result 'RailsBridge-VM:~/workspace$'
+  result 'RailsBridge-VM:/vagrant$'
 end
 
 further_reading do

--- a/sites/en/workshop/command_line.deck.md
+++ b/sites/en/workshop/command_line.deck.md
@@ -86,22 +86,22 @@ You can navigate down (into a directory) or up (to the containing, or "parent" d
 
 # Try it!
 
-When you ran `ls`, you probably saw `workspace`. That's a directory. (If you didn't, ask a TA!).
+When you ran `ls`, you probably saw `Desktop`. That's a directory. (If you didn't, ask a TA!).
 
 Type this and press **Return** or **Enter**:
 
-    cd workspace
+    cd Desktop
 
-# In the workspace
+# In the desktop folder
 
 From now on, I'll just say "run" for new commands.
 
 Run:
 
-    mkdir railsbridge_ruby
+    mkdir example_folder
     ls
 
-You should see the `railsbridge_ruby` both on your computer's desktop and in the output of `ls`.
+You should see the `example_folder` both on your computer's desktop and in the output of `ls`.
 
 # Errors
 
@@ -116,7 +116,7 @@ I'll show you what happens if the directory already exists.
 
 Run:
 
-    cd railsbridge_ruby
+    cd example_folder
     ls
 
 Nothing there yet!
@@ -136,7 +136,7 @@ Run:
 
     cd ..
 
-`..` goes "up" one directory. Now we're back in `workspace`.
+`..` goes "up" one directory. Now we're back in `Desktop`.
 
 # Going back up again
 
@@ -172,7 +172,7 @@ To get back to your home directory. This works from anywhere. `~` is the tilde k
 
 Try it! Run:
 
-    cd workspace/railsbridge_ruby
+    cd Desktop/example_folder
     ls
     cd ~
 
@@ -182,15 +182,15 @@ That's a forward slash. It separates directories.
 
 The command line relies heavily on locating files via their names. This is called a *path*.
 
-We used a path from your home directory to `railsbridge_ruby`: (this is not a command)
+We used a path from your home directory to `example_folder`: (this is not a command)
 
-    workspace/railsbridge_ruby
+    Desktop/example_folder
 
 # Files and Paths (continued)
 
 We can also give this path to other commands. Run:
 
-    ls workspace/railsbridge_ruby
+    ls Desktop/example_folder
 
 A **path** allows you to give the command a file or directory without `cd`ing to it first.
 
@@ -198,7 +198,7 @@ A **path** allows you to give the command a file or directory without `cd`ing to
 
 In this command:
 
-    ls workspace/railsbridge_ruby
+    ls Desktop/example_folder
 
 The first word, `ls` is the command. The computer finds the `ls` program and runs it.
 
@@ -244,12 +244,12 @@ If you're feeling confident, try answering this. The command `rm` (short for **r
 
 This will work:
 
-    rm workspace/railsbridge_ruby/testing_the_command_line.txt
+    rm Desktop/example_folder/testing_the_command_line.txt
 
 So will this:
 
-    cd workspace
-    cd railsbridge_ruby
+    cd Desktop
+    cd example_folder
     rm testing_the_command_line.txt
 
 There are always lots of ways to do things.
@@ -258,11 +258,11 @@ There are always lots of ways to do things.
 
 What if I want a command to work from anywhere? A path to a file can also be *absolute*. Run:
 
-    ls ~/workspace/railsbridge_ruby
+    ls ~/Desktop/example_folder
 
 What does `ls` actually see here? We can use `echo`, which is a command that just outputs ("echoes") its arguments:
 
-    echo ~/workspace/railsbridge_ruby
+    echo ~/Desktop/example_folder
 
 You will see the full path, starting with `/home` or `/Users`. A path starting with a `/` works from anywhere. The shell expanded it for you before running `echo`.
 

--- a/sites/en/workshop/command_line_2016.deck.md
+++ b/sites/en/workshop/command_line_2016.deck.md
@@ -77,28 +77,29 @@ Get thee to a terminal. *(Hint: don't type the "$")*
 # I Like to Move It, Move, It
 
 1. `pwd` *print working directory == where are we?*
-  * `/home/vagrant/workspace`
-1. `cd` *change directory (no arguments) == go home*
+  * `/vagrant`
+1. `cd ..` *change directory to .. == go up one level*
+1. `cd bin` *change directory to "bin"*
 1. `pwd` *We've moved! (unless you are **not** in a VM)*
-  * `/home/vagrant`
+  * `/bin`
 1. `ls` *list contents == see what's here*
-  * `workspace`
-1. `cd workspace` *change directory (with an argument) == go there*
+  * `vm.rb`
+1. `cd /vagrant` *change directory (with an argument) == go there*
    1. `cd <some directory>` *directories are often a different color or bolded on a modern terminal*
 1. `pwd` *We've moved again!*
-  * `/home/vagrant/workspace`
+  * `/vagrant`
 
 **Who did it perfectly?**
 
 
 # Whoa
 
-* Note the difference: `cd` versus `cd workspace`
-* Relative Path: relates to where we currently are
-  * `cd workspace` uses an *relative* path.  "change to the workshop directory from here"
-* Absolute Page: fully specified from the top (apex) on down
-  * `/home/vagrant/workspace` is an *absolute* path.
-  * It starts at root (`/`) and descends through `home`, `vagrant`, and into `workspace`
+* Note the difference: `cd bin` versus `cd /vagrant`
+# Relative Path: relates to where we currently are
+  * `cd ..` and `cd bin` use *relative* paths.  "change to the bin directory from here"
+* Absolute Path: fully specified from the top (apex) on down
+  * `/vagrant` is an *absolute* path.
+  * It starts at root (`/`) and descends into `vagrant`.
 
 # More Key Ideas
 
@@ -144,7 +145,7 @@ We've created some structure with which we can now play
 * How do you know you're there?
 * How do you see what is in the current directory?
 * How do you go **up** one directory?
-* Test: find the directory that has `dir_1`, `dir_2`, and `workspace` directories in it
+* Test: find the directory that has `dir_1`, `dir_2`, and `suggestotron` (if you've created the app) directories in it
 * Test: find the directory that has `file_2` in it
 
 # Answers
@@ -155,7 +156,7 @@ We've created some structure with which we can now play
   * `pwd`
 * How do you see what is in the current directory?
   * `ls` or `ls -l`
-* Test: find the directory that has `dir_1`, `dir_2`, and `workspace` directories in it
+* Test: find the directory that has `dir_1`, `dir_2`, and `suggestotron` (if you've created the app) directories in it
   * `cd`
   * `ls -l`
 * Test: find the directory that has `file_2` in it
@@ -167,16 +168,16 @@ We've created some structure with which we can now play
 
 # A bit about what we see
 
-     RailsBridge-VM:~/workspace$
+     RailsBridge-VM:/vagrant$
 
 * This is the **command line prompt**.
   * It can be customized (advanced topic), but you should know that you are in control of the computer.
 * The first part, "RailsBrige-VM" is the name of the machine
   * Remember, a Virtual Machine, VM, thinks it's a real computer and acts like one
 * The `:` is simply a spacer
-* The `~` is a shortcut that refers to your home directory
 * The `/` (or `\` if you're on Windows) is a directory separator
 * The `$` is the prompt -- the final character after which you can type
+* You also might see `~`, which is a shortcut that refers to your home directory
 
 # A bit about file listings
 
@@ -186,7 +187,6 @@ We've created some structure with which we can now play
     total 8
     drwxrwxr-x 3 vagrant vagrant 4096 Apr  1 00:31 dir_1
     drwxrwxr-x 2 vagrant vagrant 4096 Apr  1 00:31 dir_2
-    lrwxrwxrwx 1 vagrant vagrant    8 Jun 23  2015 workspace -> /vagrant
 
 * `d` is a **directory**
 * `l` is a **link** (advanced topic)


### PR DESCRIPTION
This is a big change so we're gonna have to go over it with TAs
beforehand. The shared folder location on the host (i.e. student laptop)
will be:

```
~/Desktop/railsbridge
```

This is the location of the Desktop in both Windows 7+ and OS X.
"Desktop" is capitalized. "railsbridge" should be lowercase always in
case someone's computer has a case-sensitive filesystem, and it's just
easier to type. On the guest VM, we will now use the default share location of

```
/vagrant
```

This changes some command line extra-credit stuff to match, so that all
the commands are still valid, and so those could use some improvement to
make the explanations flow more naturally again. We'll figure it out at
the workshop.
