### PR TITLE
Nudge students forward as they complete installfest tasks

### DIFF
--- a/sites/en/installfest/install_a_text_editor.md
+++ b/sites/en/installfest/install_a_text_editor.md
@@ -53,4 +53,6 @@ Save the User Settings file (`File > Save`). Your new preferences are now in eff
 
 Now you have an editor that you can use to open any text file, including Ruby programs.
 
-[« Back to Installfest](/installfest)
+## Next Step
+
+You've got everything! Proceed to the [Checklist](/installfest/checklist).

--- a/sites/en/installfest/linux.md
+++ b/sites/en/installfest/linux.md
@@ -19,4 +19,7 @@ Don't have these files yet? Go back to the <a href="/downloads">Downloads page</
     You will need to unpack the .tar.bz2 file and follow the
     instructions inside. Ask a TA if you have any questions.
 
-[« Back to Installfest](/installfest)
+## Next Step
+
+Once you've installed these programs, continue to [Setting Up Your Virtual
+Machine](/installfest/set_up_virtual_machine).

--- a/sites/en/installfest/linux_non-vm.md
+++ b/sites/en/installfest/linux_non-vm.md
@@ -65,4 +65,7 @@ ruby 2.0.0p451 (2014-02-24) [i686-linux]
 Congratulations, you now have the Ruby development environment up and
 running. Now go forth and do something awesome with it!
 
-[« Back to Installfest](/installfest)
+## Next Step
+
+Once you've installed these programs, continue to [Setting Up Your Virtual
+Machine](/installfest/set_up_virtual_machine).

--- a/sites/en/installfest/osx.md
+++ b/sites/en/installfest/osx.md
@@ -22,4 +22,7 @@ Don't have these files yet? Go back to the <a href="/downloads">Downloads page</
     Sublime Text app to your Applications folder. Then eject the disk
     image.
 
-[« Back to Installfest](/installfest)
+## Next Step
+
+Once you've installed these programs, continue to [Setting Up Your Virtual
+Machine](/installfest/set_up_virtual_machine).

--- a/sites/en/installfest/osx_non-vm.md
+++ b/sites/en/installfest/osx_non-vm.md
@@ -79,4 +79,7 @@ rbenv rehash
 
 Congratulations, you now have the Ruby development environment up and running. Now go forth and do something awesome with it!
 
-[« Back to Installfest](/installfest)
+## Next Step
+
+Once you've installed these programs, continue to [Setting Up Your Virtual
+Machine](/installfest/set_up_virtual_machine).

--- a/sites/en/installfest/set_up_virtual_machine.md
+++ b/sites/en/installfest/set_up_virtual_machine.md
@@ -153,4 +153,7 @@ inconvenient to get to on your keyboard:
     cd Desktop
     cd railsbridge
 
-[« Back to Installfest](/installfest)
+## Next Step
+
+Now that you've got your VM, it's time to [Try Your Text
+Editor](/installfest/install_a_text_editor).

--- a/sites/en/installfest/windows_7.md
+++ b/sites/en/installfest/windows_7.md
@@ -26,4 +26,7 @@ Don't have these files yet? Go back to the <a href="/downloads">Downloads page</
     security warning, click "Run" to allow the installer to run.
     Accept all default setup options.
 
-[« Back to Installfest](/installfest)
+## Next Step
+
+Once you've installed these programs, continue to [Setting Up Your Virtual
+Machine](/installfest/set_up_virtual_machine).

--- a/sites/en/installfest/windows_xp.md
+++ b/sites/en/installfest/windows_xp.md
@@ -33,4 +33,7 @@ Don't have these files yet? Go back to the <a href="/downloads">Downloads page</
     circle with a cat), or locate **Git Shell** in All Programs under
     GitHub. A new (mostly black) window will open.
 
-[« Back to Installfest](/installfest)
+## Next Step
+
+Once you've installed these programs, continue to [Setting Up Your Virtual
+Machine](/installfest/set_up_virtual_machine).


### PR DESCRIPTION
One of the things that I think contributes to installfest confusion is
that you go to step 1, follow a link back, go to step 2, follow another
link back, etc.

Instead, let's have step 1 link forward to step 2 and so on. You can
still use the back button, of course, but we'll make it easier to
proceed in a linear fashion.
