### PR TITLE
Break out the choose-your-OS install step thing into its own page

### DIFF
--- a/sites/en/installfest/install_environment.md
+++ b/sites/en/installfest/install_environment.md
@@ -1,0 +1,40 @@
+# Install your Programming Environment
+
+Choose the instructions below for your operating system. Most students will
+have one of the operating systems in this row.
+
+<table class="downloads-files">
+  <tr>
+    <th>Mac OS X (10.6+)</th>
+    <th>Windows (7+)</th>
+    <th>Windows (XP-Vista)</th>
+    <th>Linux (Ubuntu/Fedora)</th>
+  </tr>
+  <tr>
+    <td>Follow the <a href="/installfest/osx">Mac OS X Setup</a> instructions</td>
+    <td>Follow the <a href="/installfest/windows_7">Windows (7+) Setup</a> instructions</td>
+    <td>Follow the <a href="/installfest/windows_xp">Windows Setup</a> instructions</td>
+    <td>Follow the <a href="/installfest/linux">Linux Setup</a> instructions</td>
+  </tr>
+</table>
+
+If you have one of the operating systems in the next row below, let a TA know,
+in case we need to offer extra assistance.
+
+<table class="downloads-files">
+<tr>
+  <th>Mac OS X (10.4-10.5)</th>
+  <th>Linux (Other Distributions)</th>
+  <th>ChromeOS (Chromebook)</th>
+</tr>
+<tr>
+  <td>Follow the <a href="/installfest/osx_novm">Mac OS X non-VM Setup</a> instructions</td>
+  <td>Follow the <a href="/installfest/linux_novm">Linux non-VM Setup</a> instructions</td>
+  <td>Ask a TA</a>
+</tr>
+</table>
+
+## Next Step
+
+Once you've installed the programs for your OS, continue to [Setting Up Your Virtual
+Machine](/installfest/set_up_virtual_machine).

--- a/sites/en/installfest/installfest.md
+++ b/sites/en/installfest/installfest.md
@@ -21,40 +21,8 @@ First, make sure you have downloaded the files for your operating system from
 the <a href="/downloads">Downloads page</a>. If you don't have them, you can get them
 from a TA with a USB drive.
 
-Choose the instructions below for your operating system. _This will take you to
-a new page_. Use your browser's back button to return here. Most students will
-have one of the operating systems in this row.
-
-<table class="downloads-files">
-  <tr>
-    <th>Mac OS X (10.6+)</th>
-    <th>Windows (7+)</th>
-    <th>Windows (XP-Vista)</th>
-    <th>Linux (Ubuntu/Fedora)</th>
-  </tr>
-  <tr>
-    <td>Follow the <a href="/installfest/osx">Mac OS X Setup</a> instructions</td>
-    <td>Follow the <a href="/installfest/windows_7">Windows (7+) Setup</a> instructions</td>
-    <td>Follow the <a href="/installfest/windows_xp">Windows Setup</a> instructions</td>
-    <td>Follow the <a href="/installfest/linux">Linux Setup</a> instructions</td>
-  </tr>
-</table>
-
-If you have one of the operating systems in the next row below, let a TA know,
-in case we need to offer extra assistance.
-
-<table class="downloads-files">
-<tr>
-  <th>Mac OS X (10.4-10.5)</th>
-  <th>Linux (Other Distributions)</th>
-  <th>ChromeOS (Chromebook)</th>
-</tr>
-<tr>
-  <td>Follow the <a href="/installfest/osx_novm">Mac OS X non-VM Setup</a> instructions</td>
-  <td>Follow the <a href="/installfest/linux_novm">Linux non-VM Setup</a> instructions</td>
-  <td>Ask a TA</a>
-</tr>
-</table>
+Then, go to the [Install your Environment](/installfest/install_environment) page
+and run the installation programs for your OS.
 
 ### 2. Set up your Virtual Machine
 


### PR DESCRIPTION
A long-standing problem with the main installfest page is that step 1 is
big and full of tables, so there isn't an effective visual hierarchy
communicating that there are 4 steps.

This moves the choose-your-OS content out to a separate page. It's based
on the previous PR so it also links forward to step 2 at the bottom of
the page.

You can see how the main installfest page will look here:
https://rbdocs-df-staging.herokuapp.com/installfest/
