### PR TITLE
Fix the double flash message

### DIFF
--- a/sites/en/intro-to-rails/redirect_to_the_topics_list_after_creating_a_new_topic.step
+++ b/sites/en/intro-to-rails/redirect_to_the_topics_list_after_creating_a_new_topic.step
@@ -64,6 +64,11 @@ message "In the same file, locate the update method. "
     <div><%= message %></div>
 <% end %>
       RUBY
+
+      message "Open `app/views/topics/index.html.erb`."
+
+      message "Find the line starting with `<p id=...` at the top of the file and remove it. Otherwise you will see two identical messages when you create each new topic."
+
   end
 
   step "Confirm your changes" do


### PR DESCRIPTION
The rails scaffold adds a line to the index and show view of every
scaffold:

```
<p id="notice"><%= notice %></p>
```

When we ask students to add flash messages to the layout, the additional
scaffold-added notice messages are also displayed. A lot of people
reported this at the last workshop.

I opted to remove the scaffold lines in favor of the more versatile code that we're instructing, but it could go the other way. I'd love some thoughts either way.