### PR TITLE
Color code terminal and irb code blocks

### DIFF
--- a/assets/stylesheets/step.scss
+++ b/assets/stylesheets/step.scss
@@ -229,19 +229,56 @@ table.bordered tr {
   background-color: #C8A9E0;
 }
 
-.console > pre {
-  border: 4px solid #dde;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  -ms-border-radius: 4px;
-  -o-border-radius: 4px;
-  border-radius: 4px;
+.console pre {
   background-color: black;
+  border-radius: 4px;
+  border-top-left-radius: 0;
+  border-style:solid;
+  border-width: 4px;
   color: white;
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+.console .wrapper {
+  margin-bottom: 1em;
+  margin-top: 1em;
+}
+
+.label {
+  border-radius: 4px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  display: inline-block;
+  font-size: 8pt;
+  font-weight: bold;
+  letter-spacing: 1px;
+  padding: 0.2em 0.5em;
+  text-transform: uppercase;
 }
 
 .console {
   margin-top: 10px;
+}
+
+.console.shell {
+  .label {
+    background-color: #82DCFF;
+  }
+
+  pre {
+    border-color: #82DCFF;
+  }
+}
+
+.console.irb {
+  .label {
+    background-color: #EC635C;
+  }
+
+  pre {
+    border-color: #EC635C;
+  }
 }
 
 .fuzzy-result {
@@ -355,4 +392,3 @@ table.bordered tr {
   margin-left: auto;
   margin-right: auto;
 }
-

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -257,9 +257,12 @@ class Step < Erector::Widget
   end
 
   def console_with_message(message, commands)
-    div :class => "console" do
+    div :class => "console terminal" do
       span message
-      pre commands.strip_heredoc
+      div class: "wrapper" do
+        span "Terminal", class: "label"
+        pre commands.strip_heredoc
+      end
     end
   end
 
@@ -273,9 +276,12 @@ class Step < Erector::Widget
   end
 
   def irb msg
-    div :class => "console" do
+    div :class => "console irb" do
       span I18n.t("captions.irb")
-      pre msg.strip_heredoc
+      div class: "wrapper" do
+        span "IRB", class: "label"
+        pre msg.strip_heredoc
+      end
     end
   end
 

--- a/spec/step_spec.rb
+++ b/spec/step_spec.rb
@@ -123,14 +123,34 @@ describe Step do
   end
 
   describe 'console' do
-    it "emits a 'console' div with a 'pre' block" do
+    it "emits a 'console terminal' div with a 'pre' block" do
       html_doc(<<-RUBY)
         console "echo hi"
       RUBY
       assert_loosely_equal(@html, <<-HTML.strip_heredoc)
-        <div class="console">
+        <div class="console terminal">
           <span>#{I18n.t('captions.terminal')}</span>
-          <pre>echo hi</pre>
+          <div class="wrapper">
+            <span class="label">Terminal</span>
+            <pre>echo hi</pre>
+          </div>
+        </div>
+      HTML
+    end
+  end
+
+  describe 'irb' do
+    it "emits a 'console irb' div with a 'pre' block" do
+      html_doc(<<-RUBY)
+        irb "1 + 1"
+      RUBY
+      assert_loosely_equal(@html, <<-HTML.strip_heredoc)
+        <div class="console irb">
+          <span>#{I18n.t('captions.irb')}</span>
+          <div class="wrapper">
+            <span class="label">IRB</span>
+            <pre>1 + 1</pre>
+          </div>
         </div>
       HTML
     end


### PR DESCRIPTION
Many students would type the code into the wrong place, either bash instructions to irb or visa versa. This adds high-contrast colors around each box as well as an attached label. The colors also take in to account color-blind users.

**Unmodified screenshot:**
![unmodified](https://cloud.githubusercontent.com/assets/49549/25711310/9f024be2-30bc-11e7-86f8-3214c2a51eda.png)

**Protanopia Color-blindness:**
![protanopia](https://cloud.githubusercontent.com/assets/49549/25711332/a6cec4b8-30bc-11e7-86cf-60c35b9ace68.png)

