### PR TITLE
Fix regression with terminal and IRB color coded blocks

### DIFF
--- a/assets/stylesheets/step.scss
+++ b/assets/stylesheets/step.scss
@@ -261,7 +261,7 @@ table.bordered tr {
   margin-top: 10px;
 }
 
-.console.shell {
+.console.terminal {
   .label {
     background-color: #82DCFF;
   }


### PR DESCRIPTION
Technically, this isn't a regression because it never worked in a
shipped version. I was trying to decide between `terminal` and `shell`
for class names and ended up never picking one... `:facepalm:`

I picked terminal.