### PR TITLE
Remove links to other curricula

### DIFF
--- a/sites/en/docs/docs.step
+++ b/sites/en/docs/docs.step
@@ -12,44 +12,14 @@ site_desc 'installfest', <<-MARKDOWN
 Instructions for installing the software on your computer in order to use Ruby and Rails.
 MARKDOWN
 
-h1 'Ruby'
-
-site_desc 'ruby', <<-MARKDOWN
-A ruby-specific curriculum, expanded from the "Ruby for Beginners" slide deck. Still new, with room for your contributions.
-MARKDOWN
-
-site_desc 'learn-to-code', <<-MARKDOWN
-A course which teaches how to code from the ground up, using Alex's [Learn To Code In Ruby](http://codelikethis.com/lessons/learn_to_code) curriculum. It's geared towards people who may never have written code before and teaches just enough Ruby to get across basic principles like variables, objects, and the command line.
-MARKDOWN
-
-h1 'Rails'
+h1 'Tutorials'
 
 site_desc 'intro-to-rails', <<-MARKDOWN
 The "classic" RailsBridge curriculum (Suggestotron). Takes you step-by-step through making a Rails app, one command at a time, using helpers like `rails generate scaffold`, and deploying that app to the Internet.
 MARKDOWN
 
-site_desc 'job-board', <<-MARKDOWN
-Build a simple job board from scratch with a little less of the magic of Rails scaffolding. This curriculum is great for a second or third RailsBridge attendee or for students who want to focus on how the app is wired together. (This curriculum doesn't include deploying to the Internet.)
-MARKDOWN
-
-site_desc 'intermediate-rails', <<-MARKDOWN
-Curriculum for students who have completed the Suggestotron and the Job Board curricula. 'Easy mode' is now OFF - this curriculum won't tell you what to type in!
-MARKDOWN
-
-h1 'Frontend'
-
-site_desc 'frontend', <<-MARKDOWN
-HTML + CSS for beginners. Make a website, no server required!
-MARKDOWN
-
-site_desc 'javascript-snake-game', <<-MARKDOWN
-A Javascript specific curriculum that walks you through building a simple game.
-MARKDOWN
-
-h1 'Other'
-
-site_desc 'workshop', <<-MARKDOWN
-The Railsbridge junkyard! Slide decks for opening/closing presentations, teacher training.
+site_desc 'ruby', <<-MARKDOWN
+A Ruby-specific curriculum, expanded from the "Ruby for Beginners" slide deck. Still new, with room for your contributions.
 MARKDOWN
 
 message <<MARKDOWN


### PR DESCRIPTION
We don't teach this material, so it doesn't make sense to list them on
the site. It mostly just confuses people anyway.

![docs - docs 2017-08-16 15-36-50](https://user-images.githubusercontent.com/602470/29381919-eb14e00c-8298-11e7-8528-aba33bb140c9.jpg)
