### PR TITLE
pin 'wrong' gem to a commit on master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,11 @@
 source "https://rubygems.org"
 
+# ensure github sources are fetched securely
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
 ruby "2.2.0"
 
 gem "activesupport"
@@ -21,7 +27,7 @@ gem "jquery-cdn"
 gem "sprockets"
 
 group :development do
-  gem "wrong", "~> 0.7.0"
+  gem "wrong", github: "sconover/wrong", ref: "9fae5b82" # remove when 0.7.2+ is released
   gem "rspec"
   gem "rerun"
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/sconover/wrong.git
+  revision: 9fae5b82b3704c7bbf61b36fb9015090511742bd
+  ref: 9fae5b82
+  specs:
+    wrong (0.7.1)
+      diff-lcs (~> 1.2.5)
+      predicated (~> 0.2.6)
+      ruby2ruby (>= 2.0.1)
+      ruby_parser (>= 3.0.1)
+      sexp_processor (>= 4.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -75,14 +87,14 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
-    ruby2ruby (2.1.3)
+    ruby2ruby (2.4.1)
       ruby_parser (~> 3.1)
-      sexp_processor (~> 4.0)
-    ruby_parser (3.6.3)
-      sexp_processor (~> 4.1)
+      sexp_processor (~> 4.6)
+    ruby_parser (3.11.0)
+      sexp_processor (~> 4.9)
     rubyzip (1.1.6)
     sass (3.4.8)
-    sexp_processor (4.4.4)
+    sexp_processor (4.10.1)
     sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -105,12 +117,6 @@ GEM
     trollop (2.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    wrong (0.7.1)
-      diff-lcs (~> 1.2.5)
-      predicated (~> 0.2.6)
-      ruby2ruby (>= 2.0.1)
-      ruby_parser (>= 3.0.1)
-      sexp_processor (>= 4.0)
 
 PLATFORMS
   ruby
@@ -139,4 +145,4 @@ DEPENDENCIES
   sinatra (~> 1.4.0)
   sprockets
   thin
-  wrong (~> 0.7.0)
+  wrong!


### PR DESCRIPTION
Since the `wrong` gem hasn't had a release in 4+ years, it's been causing failures in this repo and breaking builds - 
https://github.com/railsbridge-boston/docs/pull/95#issuecomment-373751863
https://github.com/railsbridge/docs/issues/479

#### proposed solution:
* Pin the gem to a specific commit with the fix. As of right now, it happens to be the tip of `master`.