### PR TITLE
add operating system check page

### DIFF
--- a/sites/en/downloads/operating_system_checker.md
+++ b/sites/en/downloads/operating_system_checker.md
@@ -1,0 +1,99 @@
+<table>
+  <tr><td>Your Operating System name:</td><th id="os"></th></tr>
+  <tr><td>Your Operating System version:</td><th id="version"></th></tr>
+  <tr><td>Your Operating System bitness:</td><th id="bitness"></th></tr>
+</table>
+
+<div id="useragent"></div>
+
+<script>
+  // with help from (MIT license):
+  // https://github.com/barisaydinoglu/Detectizr/blob/master/src/detectizr.js
+  var UA = {
+    userAgent: null,
+    getUserAgentStr: function() {
+      return (navigator.userAgent || navigator.vendor || window.opera || "").toLowerCase()
+    },
+    is: function(key) { return UA.userAgent.indexOf(key) > -1 },
+    test: function(regex) { return regex.test(UA.userAgent) },
+    setVersion: function(os, version, modern) {
+      os.version = version
+      os.modern = modern
+    },
+    detectOSX: function(os, version) {
+      var map = UA.osxVersions
+      for (var key in map) {
+        if (map.hasOwnProperty(key) && RegExp("("+key+")").test(version)) {
+          os.version = map[key].name
+          os.bitness = map[key].bitness
+          os.modern = map[key].modern
+          return
+        }
+      }
+      os.version = "unknown"
+      os.bitness = "unknown"
+    },
+    osxVersions: {
+      "10_6": {name: "10.6 Snow Leopard", bitness: "unknown"},
+      "10_7": {name: "10.7 Lion", bitness: "64bit"},
+      "10_8": {name: "10.8 Mountain Lion", bitness: "64bit"},
+      "10_9": {name: "10.9 Mavericks", bitness: "64bit"},
+      "10_10": {name: "10.10 Yosemite", bitness: "64bit", modern: true},
+      "10_11": {name: "10.11 El Capitan", bitness: "64bit", modern: true},
+      "10_12": {name: "10.12 Sierra", bitness: "64bit", modern: true},
+      "10_13": {name: "10.13 High Sierra", bitness: "64bit", modern: true}
+    },
+    detect: function(userAgent) {
+      UA.userAgent = userAgent.toLowerCase()
+      var os = { modern: false }
+      if (UA.is("win") || UA.is("16bit")) {
+        os.name = "Windows"
+        if (UA.is("windows nt 10")) {
+          UA.setVersion(os, "10", true)
+        } else if (UA.is("windows nt 6.3")) {
+          UA.setVersion(os, "8.1", true)
+        } else if (UA.is("windows nt 6.2") || UA.test(/\(windows 8\)/)) {
+          UA.setVersion(os, "8", true)
+        } else if (UA.is("windows nt 6.1")) {
+          UA.setVersion(os, "7")
+        } else if (UA.is("windows nt 6.0")) {
+          UA.setVersion(os, "vista")
+        } else if (UA.is("windows nt 5.2") || UA.is("windows nt 5.1") || UA.is("windows xp")) {
+          UA.setVersion(os, "xp")
+        } else if (UA.is("windows nt 5.0") || UA.is("windows 2000")) {
+          UA.setVersion(os, "2k")
+        } else if (UA.is("winnt") || UA.is("windows nt")) {
+          UA.setVersion(os, "nt")
+        } else if (UA.is("win98") || UA.is("windows 98")) {
+          UA.setVersion(os, "98")
+        } else if (UA.is("win95") || UA.is("windows 95")) {
+          UA.setVersion(os, "95")
+        }
+      } else if (UA.is("mac") || UA.is("darwin")) {
+        os.name = "Mac OS"
+        if (UA.is("68k") || UA.is("68000")) {
+          UA.setVersion(os, "68k")
+        } else if (UA.is("ppc") || UA.is("powerpc")) {
+          UA.setVersion(os, "ppc")
+        } else if (UA.is("os x")) {
+          if (UA.test(/os\sx\s([\d_]+)/) ) {
+            os.name = "Mac OS X"
+            UA.detectOSX(os, RegExp.$1)
+          }
+        }
+      } else if (UA.is("x11") || UA.is("inux")) {
+        os.name = "Linux"
+      }
+      if (UA.test(/\sx64|\sx86|\swin64|\swow64|\samd64/)) {
+        os.bitness = "64bit"
+      }
+      return os
+    }
+  }
+
+  var os = UA.detect(UA.getUserAgentStr())
+
+  document.getElementById('os').innerHTML = os.name
+  document.getElementById('bitness').innerHTML = os.bitness || "unknown"
+  document.getElementById('version').innerHTML = os.version || "unknown"
+</script>


### PR DESCRIPTION
Problem: Will my laptop work with railsbridge? What should I download? What OS version do I have? What OS am I running? (usually a prerequisite for finding the specific version)

Solution: 

![image](https://user-images.githubusercontent.com/222655/38783349-a65c458c-40ce-11e8-8066-e67badc1a480.png)


Just an idea I was playing around with. Didn't know the best place to stick test cases so here are a few I tried by hand:

```javascript
// {modern: undefined, name: "Mac OS X", version: "10.6 Snow Leopard", bitness: "unknown"}
UA.detect("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.57 Safari/537.17")

// {modern: undefined, name: "Windows", version: "7", bitness: "64bit"}
UA.detect("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:54.0) Gecko/20100101 Firefox/54.0")

// {modern: true, name: "Windows", version: "10", bitness: "64bit"}
UA.detect("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36")

// {modern: true, name: "Mac OS X", version: "10.13 High Sierra", bitness: "64bit"}
UA.detect("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/604.4.7 (KHTML, like Gecko) Version/11.0.2 Safari/604.4.7")

// { modern: false, name: "Linux", bitness: "64bit" }
UA.detect("Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:59.0) Gecko/20100101 Firefox/59.0")
```




### next steps / ways to build on this
* hide non-applicable downloads by default?
* build out the "modern" flag more - either let people know they are definitely good to go, definitely need to start on cloud9, or not sure.
* recommendations based on detection results (use cloud9, go check your virtualization, etc)?

Unfortunately there is no way to detect virtualization support directly, but for suspicious combinations of attributes we could direct users to run additional checks like [Microsoft® Hardware-Assisted Virtualization Detection Tool](https://www.microsoft.com/en-us/download/details.aspx?id=592)