### PR TITLE
Clarify how to run the rails server

### DIFF
--- a/sites/en/intro-to-rails/CRUD_with_scaffolding.step
+++ b/sites/en/intro-to-rails/CRUD_with_scaffolding.step
@@ -16,7 +16,11 @@ end
 steps do
 
   step do
-    console "rails server"
+    console "rails server -b 0.0.0.0"
+    
+    cloud9_instruction do
+      console "rails server -b $IP -p $PORT"
+    end
   end
 
   step do


### PR DESCRIPTION
local / vm installs: we always want to bind to the ipv4 address. this fixes the case where the server is running but students cant connect to the server from their browser.

# Before:

![image](https://user-images.githubusercontent.com/222655/55672229-a8002100-5866-11e9-8ef4-2ce24543137d.png)


# After:
![image](https://user-images.githubusercontent.com/222655/55672227-9fa7e600-5866-11e9-911e-e827ce9dbe9d.png)
