### PR TITLE
fix cloud9 rails routes link

### DIFF
--- a/sites/en/intro-to-rails/setting_the_default_page.step
+++ b/sites/en/intro-to-rails/setting_the_default_page.step
@@ -86,10 +86,10 @@ edit_topic GET    /topics/:id/edit(.:format) topics#edit
     code in parentheses is optional.
 
     You can also get this information on your site in development. Go to
-    <http://localhost:3000/rails/info/routes> 
+    <http://localhost:3000/rails/info/routes>
   MARKDOWN
     cloud9_instruction do
-      simple_link " https://<your-preview-url>.amazonaws.com/rails/info/routes"
+      message "Navigate to `https://<your-preview-url>.amazonaws.com/rails/info/routes`"
     end
   <<-MARKDOWN
     and you'll see something like this:


### PR DESCRIPTION
Minor cosmetic update to https://docs.railsbridgeboston.org/intro-to-rails/setting_the_default_page 

It turns out if you use `simple_link`, it helpfully tries to create a link to the page in the navigation, including when said link would 404:
![image](https://user-images.githubusercontent.com/222655/55673614-3630d300-5878-11e9-9e34-ad05111dcd63.png)

The fix: switch to a less magical DSL thingy, since that link isn't made more useful by being clickable. Students need to replace it with their own personal preview url.

# before
![image](https://user-images.githubusercontent.com/222655/55673606-17cad780-5878-11e9-8c47-2530951e565f.png)


# after:
![image](https://user-images.githubusercontent.com/222655/55673604-084b8e80-5878-11e9-947f-83c92535e98c.png)
