### PR TITLE
Fix Typos on Cloud9 Installfest Instructions

### DIFF
--- a/sites/en/installfest/cloud9.md
+++ b/sites/en/installfest/cloud9.md
@@ -10,7 +10,7 @@ app that we'll be building.
 
 1. Visit the [Cloud9 website](https://c9.io)
 
-2. Click "Create new AWS ccount".
+2. Click "Create new AWS account".
 
 3. Create an account with a valid email address, password, and AWS account name (this account name can be changed later).
 

--- a/sites/en/installfest/cloud9.md
+++ b/sites/en/installfest/cloud9.md
@@ -8,7 +8,7 @@ app that we'll be building.
 
 ### Sign up for a Cloud9 account
 
-1. Visit the [Cloud9 website]("https://c9.io")
+1. Visit the [Cloud9 website](https://c9.io)
 
 2. Click "Create new AWS ccount".
 


### PR DESCRIPTION
I noticed a few typos in the installfest instructions for using Cloud9 as the dev environment.

This PR addresses those typos.

1.  Fixes a broken link on [https://docs.railsbridgeboston.org/installfest/cloud9](https://docs.railsbridgeboston.org/installfest/cloud9) to [https://c9.io]( https://c9.io)

<img width="688" alt="Screen Shot 2019-06-29 at 11 59 05 AM" src="https://user-images.githubusercontent.com/6352760/60386617-5500c900-9a65-11e9-94bc-03c5f19404d4.png">

2.  Fixes spelling of `account`.