### PR TITLE
fix link to topics

### DIFF
--- a/sites/en/intro-to-rails/redirect_to_the_topics_list_after_creating_a_new_topic.step
+++ b/sites/en/intro-to-rails/redirect_to_the_topics_list_after_creating_a_new_topic.step
@@ -55,7 +55,7 @@ message "In the same file, locate the update method. "
   end
 
   step "Confirm your changes" do
-    message "Create some new topics at <http://localhost:3000>. Notice when you create a new topic, the application takes you back to the index page with all the topics."
+    message "Create some new topics at <http://localhost:3000/topics>. Notice when you create a new topic, the application takes you back to the index page with all the topics."
   end
 end
 


### PR DESCRIPTION
It was a bit confusing that the link directed me to the index page and not /topics. This PR hopefully alleviates some of the confusion. 